### PR TITLE
Change tree icons

### DIFF
--- a/public/assets/yale.css
+++ b/public/assets/yale.css
@@ -1041,3 +1041,17 @@ mdc:  new additions for updated single-scroll view
 .infinite-item .record-type-badge {
   font-family: "Mallory-Book";
 }
+
+/* change tree icons from chevrons to plus/minus icons */
+body #tree-container .expandme .expandme-icon:before {
+    content: "\002b";
+}
+
+body #tree-container .expandme .expandme-icon.expanded:before {
+    content: "\2212";
+}
+
+body #tree-container .expandme .expandme-icon.expanded {
+    transform: none;
+    transition: none;
+}

--- a/public/views/layout_head.html.erb
+++ b/public/views/layout_head.html.erb
@@ -1,1 +1,1 @@
-<%= stylesheet_link_tag "#{@base_url}/assets/yale.css" %>
+<%= stylesheet_link_tag "#{@base_url}/assets/yale.css?_t=#{ASConstants.VERSION}" %>


### PR DESCRIPTION
Takes https://github.com/hudmol/archivesspace/pull/11 and tries to apply the same customization with pure CSS.  

I've also added a cache-break to `yale.css` so a new version/release will ensure the user doesn't have to clear their cache to get the change.